### PR TITLE
B 6.3.x unzer multipe tickets 18x 19x for RC5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### NEW
 - New Payment PayLater
 ### FIXED
+- Fixed ApplePay admin settings not saving the merchant certificate properly.
 - New country restrictions based on the Unzer documentation
   - ALIPAY: DE, AT, BE, IT, ES, NL
-  - Installment: DE, AT, CH
+  - ~~Installment: DE, AT, CH~~ (payment method deprecated)
   - Unzer Invoice (Paylater): DE, AT, CH, NL
   - Prepayment: all Countries
   - SEPA Direct Debit: DE, AT
@@ -28,6 +29,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [0007447](https://bugs.oxid-esales.com/view.php?id=7447) Markup due to negative discount per shopping cart leads to maintainance mode
 - [0007439](https://bugs.oxid-esales.com/view.php?id=7439) Chargeback transactions do not appear in the backend
 - [0007442](https://bugs.oxid-esales.com/view.php?id=7442) Reversal after partial reversal
+
+### CHANGES
+Unzer has **deprecated** following payment methods, which will be set to inactive:
+- Installment / Ratenzahlung
+- Unzer Direct Debit Secured/ SEPA Lastschrift (abgesichert durch Unzer)
+- Bank transfer
+
+> Inactive Payment methods are not removed to avoid inaccessible payments of these types in the backend.\
+>  Merchants **should not use deprecated payment methods** in the frontend anymore.
+
 
 ## [1.0.1] - 2022-12-03
 

--- a/metadata.php
+++ b/metadata.php
@@ -51,7 +51,7 @@ $aModule = [
             </ul>',
     ],
     'thumbnail' => 'logo.svg',
-    'version' => '1.1.0-rc.4',
+    'version' => '1.1.0-rc.5',
     'author' => 'OXID eSales AG',
     'url' => 'https://www.oxid-esales.com',
     'email' => 'info@oxid-esales.com',

--- a/metadata.php
+++ b/metadata.php
@@ -204,12 +204,6 @@ $aModule = [
             'constraints' => '0|1'
         ],
         [
-            'group' => 'unzerinstallment',
-            'name' => 'UnzerOption_oscunzer_installment_rate',
-            'type' => 'str',
-            'value' => '4.5'
-        ],
-        [
             'group' => 'unzerapplepay',
             'name' => 'UnzerOption_oscunzer_applepay',
             'type' => 'select',

--- a/src/Controller/Admin/ModuleConfiguration.php
+++ b/src/Controller/Admin/ModuleConfiguration.php
@@ -334,13 +334,13 @@ class ModuleConfiguration extends ModuleConfiguration_parent
             if (is_array($applePayNetworks)) {
                 $this->moduleSettings->saveApplePayNetworks($applePayNetworks);
             }
-            $certConfigKey = $systemMode . '-' . 'applePayMerchantCert';
+            $certConfigKey = $this->moduleSettings->getSystemMode() . '-' . 'applePayMerchantCert';
             $applePayMerchantCert = $request->getRequestEscapedParameter($certConfigKey);
             file_put_contents(
                 $this->moduleSettings->getApplePayMerchantCertFilePath(),
                 $applePayMerchantCert
             );
-            $keyConfigKey = $systemMode . '-' . 'applePayMerchantCertKey';
+            $keyConfigKey = $this->moduleSettings->getSystemMode() . '-' . 'applePayMerchantCertKey';
             $applePayMerchCertKey = $request->getRequestEscapedParameter($keyConfigKey);
             file_put_contents(
                 $this->moduleSettings->getApplePayMerchantCertKeyFilePath(),

--- a/src/Controller/Admin/ModuleConfiguration.php
+++ b/src/Controller/Admin/ModuleConfiguration.php
@@ -200,7 +200,7 @@ class ModuleConfiguration extends ModuleConfiguration_parent
                     $errorMessage = 'OSCUNZER_ERROR_TRANSMITTING_APPLEPAY_PAYMENT_SET_KEY';
                 } else {
                     /** @var array{'id': string} $responseBody */
-                    $responseBody = json_decode($response->getBody()->__toString());
+                    $responseBody = json_decode($response->getBody()->__toString(), true);
                     $applePayKeyId = $responseBody['id'];
                 }
             } catch (Throwable $loggerException) {
@@ -216,7 +216,7 @@ class ModuleConfiguration extends ModuleConfiguration_parent
                     $errorMessage = 'OSCUNZER_ERROR_TRANSMITTING_APPLEPAY_PAYMENT_SET_CERT';
                 } else {
                     /** @var array{'id': string} $responseBody */
-                    $responseBody = json_decode($response->getBody()->__toString());
+                    $responseBody = json_decode($response->getBody()->__toString(), true);
                     $applePayCertId = $responseBody['id'];
                 }
             } catch (Throwable $loggerException) {
@@ -334,12 +334,14 @@ class ModuleConfiguration extends ModuleConfiguration_parent
             if (is_array($applePayNetworks)) {
                 $this->moduleSettings->saveApplePayNetworks($applePayNetworks);
             }
-            $applePayMerchantCert = $request->getRequestEscapedParameter('applePayMerchantCert');
+            $merchantCertConfigKey = $systemMode . '-' . 'applePayMerchantCert';
+            $applePayMerchantCert = $request->getRequestEscapedParameter($merchantCertConfigKey);
             file_put_contents(
                 $this->moduleSettings->getApplePayMerchantCertFilePath(),
                 $applePayMerchantCert
             );
-            $applePayMerchCertKey = $request->getRequestEscapedParameter('applePayMerchantCertKey');
+            $merchantKeyConfigKey = $systemMode . '-' . 'applePayMerchantCertKey';
+            $applePayMerchCertKey = $request->getRequestEscapedParameter($merchantKeyConfigKey);
             file_put_contents(
                 $this->moduleSettings->getApplePayMerchantCertKeyFilePath(),
                 $applePayMerchCertKey

--- a/src/Controller/Admin/ModuleConfiguration.php
+++ b/src/Controller/Admin/ModuleConfiguration.php
@@ -334,14 +334,14 @@ class ModuleConfiguration extends ModuleConfiguration_parent
             if (is_array($applePayNetworks)) {
                 $this->moduleSettings->saveApplePayNetworks($applePayNetworks);
             }
-            $merchantCertConfigKey = $systemMode . '-' . 'applePayMerchantCert';
-            $applePayMerchantCert = $request->getRequestEscapedParameter($merchantCertConfigKey);
+            $certConfigKey = $systemMode . '-' . 'applePayMerchantCert';
+            $applePayMerchantCert = $request->getRequestEscapedParameter($certConfigKey);
             file_put_contents(
                 $this->moduleSettings->getApplePayMerchantCertFilePath(),
                 $applePayMerchantCert
             );
-            $merchantKeyConfigKey = $systemMode . '-' . 'applePayMerchantCertKey';
-            $applePayMerchCertKey = $request->getRequestEscapedParameter($merchantKeyConfigKey);
+            $keyConfigKey = $systemMode . '-' . 'applePayMerchantCertKey';
+            $applePayMerchCertKey = $request->getRequestEscapedParameter($keyConfigKey);
             file_put_contents(
                 $this->moduleSettings->getApplePayMerchantCertKeyFilePath(),
                 $applePayMerchCertKey

--- a/src/Controller/OrderController.php
+++ b/src/Controller/OrderController.php
@@ -54,8 +54,7 @@ class OrderController extends OrderController_parent
         /** @var int $iLang */
         $iLang = $lang->getBaseLanguage();
         $sLang = $lang->getLanguageAbbr($iLang);
-        $sLocale = sprintf('%s_%s', $sLang, strtoupper($sLang));
-        $this->_aViewData['unzerLocale'] = $sLocale;
+        $this->_aViewData['unzerLocale'] = $sLang;
 
         // generate always a new threat metrix session id
         $unzer = $this->getServiceFromContainer(Unzer::class);

--- a/src/Controller/OrderController.php
+++ b/src/Controller/OrderController.php
@@ -45,9 +45,18 @@ class OrderController extends OrderController_parent
 
     /**
      * @inerhitDoc
+     * @SuppressWarnings(PHPMD.StaticAccess)
      */
     public function render()
     {
+        $lang = Registry::getLang();
+
+        /** @var int $iLang */
+        $iLang = $lang->getBaseLanguage();
+        $sLang = $lang->getLanguageAbbr($iLang);
+        $sLocale = sprintf('%s_%s', $sLang, strtoupper($sLang));
+        $this->_aViewData['unzerLocale'] = $sLocale;
+
         // generate always a new threat metrix session id
         $unzer = $this->getServiceFromContainer(Unzer::class);
         $this->_aViewData['unzerThreatMetrixSessionID'] = $unzer->generateUnzerThreatMetrixIdInSession();

--- a/src/Core/UnzerDefinitions.php
+++ b/src/Core/UnzerDefinitions.php
@@ -301,7 +301,7 @@ final class UnzerDefinitions
                         smaller installments. Choose this method for comfortable payment in installments.'
                 ]
             ],
-            'active' => true,
+            'active' => false, // UNZER-199
             'countries' => ['DE', 'AT', 'CH'],
             'constraints' => self::PAYMENT_CONSTRAINTS,
             'abilities' => [
@@ -474,7 +474,7 @@ final class UnzerDefinitions
                         title="Przelewy24" style="float: left;margin-right: 10px;" />'
                 ]
             ],
-            'active' => true,
+            'active' => false, // UNZER-199
             'countries' => ['DE', 'AT'],
             'constraints' => self::PAYMENT_CONSTRAINTS,
             'abilities' => [
@@ -520,7 +520,7 @@ final class UnzerDefinitions
                     'longdesc' => ''
                 ]
             ],
-            'active' => false,
+            'active' => false, // UNZER-199
             'countries' => ['DE', 'AT'],
             'constraints' => self::PAYMENT_CONSTRAINTS,
             'abilities' => [

--- a/src/Service/StaticContent.php
+++ b/src/Service/StaticContent.php
@@ -44,11 +44,21 @@ class StaticContent
             $paymentMethod = oxNew(EshopModelPayment::class);
             if ($paymentMethod->load($paymentId)) {
                 $this->updatePaymentToCountries($paymentId, $paymentDefinitions['countries']);
+                $this->checkAndDeactivatePaymentMethod($paymentDefinitions, $paymentMethod);
                 continue;
             }
             $this->createPaymentMethod($paymentId, $paymentDefinitions);
             $this->assignPaymentToCountries($paymentId, $paymentDefinitions['countries']);
             $this->assignPaymentToActiveDeliverySets($paymentId);
+        }
+    }
+
+    protected function checkAndDeactivatePaymentMethod(array $paymentDefinition, EshopModelPayment $paymentMethod): void
+    {
+        // deactivate inactive payment methods
+        if (!$paymentDefinition['active'] && $paymentMethod->oxpayments__oxactive->value == 1) {
+            $paymentMethod->oxpayments__oxactive->value = 0;
+            $paymentMethod->save();
         }
     }
 

--- a/src/Service/StaticContent.php
+++ b/src/Service/StaticContent.php
@@ -55,8 +55,10 @@ class StaticContent
 
     protected function checkAndDeactivatePaymentMethod(array $paymentDefinition, EshopModelPayment $paymentMethod): void
     {
-        // deactivate inactive payment methods
+        // TODO fixme Access to an undefined property OxidEsales\Eshop\Application\Model\Payment::$oxpayments__oxactive.
+        /** @phpstan-ignore-next-line */
         if (!$paymentDefinition['active'] && $paymentMethod->oxpayments__oxactive->value == 1) {
+            /** @phpstan-ignore-next-line */
             $paymentMethod->oxpayments__oxactive->value = 0;
             $paymentMethod->save();
         }

--- a/src/Service/Unzer.php
+++ b/src/Service/Unzer.php
@@ -344,11 +344,9 @@ class Unzer
     {
         $bPasswordIsEmpty = ($oUser->getFieldData('oxpassword') === '');
 
-        if ($bPasswordIsEmpty) { // guest user
-            $registrationLevel = '0';
-            $registrationDate = gmdate('Ymd');
-        }
-        else { // registered user
+        $registrationLevel = '0';
+        $registrationDate = gmdate('Ymd');
+        if (!$bPasswordIsEmpty) { // registered user
             $registrationLevel = '1'; // 1 = registered user
             $oxregister = $oUser->getFieldData('oxregister');
             // shouldn't happen, but if it did, it would cause an error on unzer

--- a/src/Service/Unzer.php
+++ b/src/Service/Unzer.php
@@ -342,15 +342,23 @@ class Unzer
      */
     public function getUnzerRiskData(Customer $unzerCustomer, User $oUser): RiskData
     {
-        $registrationLevel = '1'; // registered user
-        /** @var string $oxregister */
-        $oxregister = $oUser->getFieldData('oxregister');
-        if ($oxregister == '0000-00-00 00:00:00') {
-            // unregistered user aka "guest"
-            $oxregister = gmdate('Y-m-d H:i:s');
+        $bPasswordIsEmpty = ($oUser->getFieldData('oxpassword') === '');
+
+        if ($bPasswordIsEmpty) { // guest user
             $registrationLevel = '0';
+            $registrationDate = gmdate('Ymd');
         }
-        $dtRegister = new DateTime($oxregister);
+        else { // registered user
+            $registrationLevel = '1'; // 1 = registered user
+            $oxregister = $oUser->getFieldData('oxregister');
+            // shouldn't happen, but if it did, it would cause an error on unzer
+            if ($oxregister == '0000-00-00 00:00:00') {
+                $oxregister = gmdate('Y-m-d H:i:s');
+            }
+            /** @var string $oxregister */
+            $dtRegister = new DateTime($oxregister);
+            $registrationDate = $dtRegister->format('Ymd');
+        }
 
         $orderedAmount = 0.;
         /** @var ListModel $orderList */
@@ -367,7 +375,7 @@ class Unzer
             ->setConfirmedOrders($oUser->getOrderCount())
             ->setCustomerId($unzerCustomer->getCustomerId())
             ->setRegistrationLevel($registrationLevel)
-            ->setRegistrationDate($dtRegister->format('Ymd'));
+            ->setRegistrationDate($registrationDate);
 
         return $riskData;
     }

--- a/src/Service/Unzer.php
+++ b/src/Service/Unzer.php
@@ -342,8 +342,14 @@ class Unzer
      */
     public function getUnzerRiskData(Customer $unzerCustomer, User $oUser): RiskData
     {
+        $registrationLevel = '1'; // registered user
         /** @var string $oxregister */
         $oxregister = $oUser->getFieldData('oxregister');
+        if ($oxregister == '0000-00-00 00:00:00') {
+            // unregistered user aka "guest"
+            $oxregister = gmdate('Y-m-d H:i:s');
+            $registrationLevel = '0';
+        }
         $dtRegister = new DateTime($oxregister);
 
         $orderedAmount = 0.;
@@ -360,7 +366,7 @@ class Unzer
             ->setCustomerGroup(CustomerGroups::NEUTRAL) // todo: decide customer group (see doku)
             ->setConfirmedOrders($oUser->getOrderCount())
             ->setCustomerId($unzerCustomer->getCustomerId())
-            ->setRegistrationLevel('1') // registered user
+            ->setRegistrationLevel($registrationLevel)
             ->setRegistrationDate($dtRegister->format('Ymd'));
 
         return $riskData;

--- a/views/admin/blocks/admin_module_config_var.tpl
+++ b/views/admin/blocks/admin_module_config_var.tpl
@@ -43,7 +43,9 @@
             </dl>
         [{/if}]
     [{elseif $var_group eq "unzerapplepay"}]
-        [{if $module_var eq "applepay_merchant_capabilities" or $module_var eq "applepay_networks"}]
+        [{if $module_var eq "UnzerOption_oscunzer_applepay"}]
+            [{$smarty.block.parent}]
+        [{elseif $module_var eq "applepay_merchant_capabilities" or $module_var eq "applepay_networks"}]
             <dl>
                 <dd>
                     [{oxmultilang ident="SHOP_MODULE_`$module_var`"}]

--- a/views/admin/de/oscunzer_lang.php
+++ b/views/admin/de/oscunzer_lang.php
@@ -39,6 +39,7 @@ $aLang = [
     'OSCUNZER_ORDER_AMOUNT' => 'Gesamtbetrag',
     'OSCUNZER_AUTHORIZE_CANCEL_POSSIBLE' => 'Solange kein Betrag eingezogen wurde, kann die Autorisierung storniert werden.',
     'OSCUNZER_AUTHORIZE_CANCEL' => 'Autorisierung stornieren',
+    'OSCUNZER_AUTHORIZE_CANCEL_ALERT' => 'Wollen Sie wirklich für den gewählten Betrag die Authorisierung stornieren? Gewählter Betrag: ',
     'OSCUNZER_CHARGES' => 'Eingezogene Beträge',
     'OSCUNZER_CHARGED_AMOUNT' => 'Eingezogener Betrag',
     'OSCUNZER_CHARGED_CANCELLED' => 'Erstatteter Betrag',

--- a/views/admin/en/oscunzer_lang.php
+++ b/views/admin/en/oscunzer_lang.php
@@ -39,6 +39,7 @@ $aLang = [
     'OSCUNZER_ORDER_AMOUNT' => 'Grand total',
     'OSCUNZER_AUTHORIZE_CANCEL_POSSIBLE' => 'As long as no amount has been collected, the authorization can be cancelled.',
     'OSCUNZER_AUTHORIZE_CANCEL' => 'Cancel authorization',
+    'OSCUNZER_AUTHORIZE_CANCEL_ALERT' => 'Do you really want to cancel the authorization of the selected amount? chosen amount: ',
     'OSCUNZER_CHARGES' => 'Charges',
     'OSCUNZER_CHARGED_AMOUNT' => 'amount collected',
     'OSCUNZER_CHARGED_CANCELLED' => 'refunded amount',

--- a/views/admin/tpl/oscunzer_order.tpl
+++ b/views/admin/tpl/oscunzer_order.tpl
@@ -208,7 +208,7 @@
                         </tr>
                     [{/foreach}]
                     [{if $canCancelAmount > 0}]
-                        <form name="uzr" id="uzr_payout" action="[{$oViewConf->getSelfLink()}]" method="post">
+                        <form name="uzr" id="uzr_s-chg_payout" action="[{$oViewConf->getSelfLink()}]" method="post">
                             [{$oViewConf->getHiddenSid()}]
                             <input type="hidden" name="unzerid" value="[{$sPaymentId}]">
                             <input type="hidden" name="chargedamount" value="[{$canCancelAmount}]">
@@ -222,7 +222,7 @@
                                 <td>[{$totalAmountCharge|string_format:"%.2f"}] [{$uzrCurrency}]</td>
                                 <td>[{$totalAmountCancel|string_format:"%.2f"}] [{$uzrCurrency}]</td>
                                 [{if $canRefundFully}]
-                                    <td><input type="text" id="amount_payout"
+                                    <td><input type="text" id="amount_s-chg_payout"
                                                name="amount" value="[{$canCancelAmount|string_format:"%.2f"}]"> [{$uzrCurrency}]</td>
                                     <td><button type="submit">[{oxmultilang ident="OSCUNZER_PAYOUT"}]</button></td>
                                 [{else}]
@@ -278,7 +278,7 @@ let handleUnzerForm = function(formElement) {
         let inAmount = document.getElementById(amountId);
 
         if (null !== inAmount) {
-            return window.confirm('[{oxmultilang ident="OSCUNZER_CANCEL_ALERT"}]' + ' ' + inAmount.value);
+            return window.confirm('[{oxmultilang ident="OSCUNZER_CANCEL_ALERT"}]' + ' ' + inAmount.value + ' [{$uzrCurrency}]');
         }
         return false;
     }

--- a/views/admin/tpl/oscunzer_order.tpl
+++ b/views/admin/tpl/oscunzer_order.tpl
@@ -118,7 +118,7 @@
                 </form>
             [{/if}]
             [{if $AuthAmountRemaining > 0}]
-                <form name="uzr" id="uzr_collect" action="[{$oViewConf->getSelfLink()}]" method="post">
+                <form name="uzr" id="uzr_authorize" action="[{$oViewConf->getSelfLink()}]" method="post">
                     <input type="hidden" name="cl" value="unzer_admin_order">
                     <input type="hidden" name="fnc" value="doUnzerAuthorizationCancel">
                     <input type="hidden" name="oxid" value="[{$oxid}]">
@@ -128,9 +128,11 @@
                         <tr>
                             <td>[{oxmultilang ident="OSCUNZER_AUTHORIZE_CANCEL_POSSIBLE"}]</td>
                             [{if $canRevertPartially}]
-                            <td><input type="text" name="amount" value="[{$AuthAmountRemaining|string_format:"%.2f"}]"> [{$AuthCur}]</td>
+                            <td><input type="text" id ="amount_authorize" name="amount"
+                                       value="[{$AuthAmountRemaining|string_format:"%.2f"}]"> [{$AuthCur}]</td>
                             [{else}]
-                            <td><input type="hidden" name="amount" value="[{$AuthAmountRemaining|string_format:"%.2f"}]"></td>
+                            <td><input type="hidden" id ="amount_authorize" name="amount"
+                                       value="[{$AuthAmountRemaining|string_format:"%.2f"}]"></td>
                             [{/if}]
                             <td><button type="submit">[{oxmultilang ident="OSCUNZER_AUTHORIZE_CANCEL"}]</button></td>
                         </tr>
@@ -270,7 +272,6 @@
     [{/block}]
 </div>
 [{capture assign="cancelConfirm"}]
-/* handle Unzer forms for refund */
 let handleUnzerForm = function(formElement) {
     if(formElement.id.indexOf('uzr_') === 0) { // make absolutely sure to start with "uzr_"
         let paymentId = formElement.id.slice(4);
@@ -286,7 +287,6 @@ let handleUnzerForm = function(formElement) {
     return true;
 };
 
-/* apply submit listener */
 document.addEventListener('DOMContentLoaded', function () {
     let forms = document.querySelectorAll('form[id^="uzr_s-chg"]');
     for(var i = 0; i < forms.length; i++) {
@@ -300,8 +300,37 @@ document.addEventListener('DOMContentLoaded', function () {
     }
 }, false);
 [{/capture}]
-
 [{oxscript add=$cancelConfirm}]
+
+[{capture assign="cancelAuthConfirm"}]
+let handleUnzerAuthForm = function(formElement) {
+    if(formElement.id.indexOf('uzr_authorize') === 0) {
+        let paymentId = formElement.id.slice(4);
+        let amountId = 'amount_' + paymentId;
+        let inAmount = document.getElementById(amountId);
+
+        if (null !== inAmount) {
+            return window.confirm('[{oxmultilang ident="OSCUNZER_AUTHORIZE_CANCEL_ALERT"}]' + ' ' + inAmount.value + ' [{$uzrCurrency}]');
+        }
+        return false;
+    }
+    return true;
+};
+
+document.addEventListener('DOMContentLoaded', function () {
+    let forms = document.querySelectorAll('form[id^="uzr_authorize"]');
+    for(var i = 0; i < forms.length; i++) {
+        forms[i].addEventListener('submit', function(event) {
+            let returnValue = handleUnzerAuthForm(this);
+            if (!returnValue) {
+                event.preventDefault();
+            }
+            return returnValue;
+        });
+    }
+}, false);
+[{/capture}]
+[{oxscript add=$cancelAuthConfirm}]
 
 [{include file="bottomnaviitem.tpl"}]
 

--- a/views/frontend/tpl/order/unzer_applepay.tpl
+++ b/views/frontend/tpl/order/unzer_applepay.tpl
@@ -3,7 +3,7 @@
     [{capture assign="unzerApplePayJS"}]
         const $errorHolder = $('#error-holder');
 
-        const unzerInstance = new unzer('[{$unzerpub}]');
+        const unzerInstance = new unzer('[{$unzerpub}]', {locale: "[{$unzerLocale}]"});
         const unzerApplePayInstance = unzerInstance.ApplePay();
         const $form = $('#orderConfirmAgbBottom');
 

--- a/views/frontend/tpl/order/unzer_card.tpl
+++ b/views/frontend/tpl/order/unzer_card.tpl
@@ -32,7 +32,7 @@
     });
 
     // Create an Unzer instance with your public key
-    let unzerInstance = new unzer('[{$unzerpub}]');
+    let unzerInstance = new unzer('[{$unzerpub}]', {locale: "[{$unzerLocale}]"});
 
     // Create a Card instance and render the input fields
     let Card = unzerInstance.Card();

--- a/views/frontend/tpl/order/unzer_eps_charge.tpl
+++ b/views/frontend/tpl/order/unzer_eps_charge.tpl
@@ -15,7 +15,7 @@
     });
 
     // Create an Unzer instance with your public key
-    let unzerInstance = new unzer('[{$unzerpub}]');
+    let unzerInstance = new unzer('[{$unzerpub}]', {locale: "[{$unzerLocale}]"});
 
     // Create an EPS instance and render the EPS form
     let EPS = unzerInstance.EPS();

--- a/views/frontend/tpl/order/unzer_ideal.tpl
+++ b/views/frontend/tpl/order/unzer_ideal.tpl
@@ -15,7 +15,7 @@
         });
 
         // Create an Unzer instance with your public key
-        let unzerInstance = new unzer('[{$unzerpub}]');
+        let unzerInstance = new unzer('[{$unzerpub}]', {locale: "[{$unzerLocale}]"});
 
         // Create an iDeal instance and render the iDeal form
         let IDeal = unzerInstance.Ideal();

--- a/views/frontend/tpl/order/unzer_installment.tpl
+++ b/views/frontend/tpl/order/unzer_installment.tpl
@@ -70,7 +70,7 @@
 [{capture assign="unzerInstallmentJS"}]
 
         // Create an Unzer instance with your public key
-        let unzerInstance = new unzer('[{$unzerpub}]');
+        let unzerInstance = new unzer('[{$unzerpub}]', {locale: "[{$unzerLocale}]"});
 
         let InstallmentSecured = unzerInstance.InstallmentSecured();
 

--- a/views/frontend/tpl/order/unzer_invoice.tpl
+++ b/views/frontend/tpl/order/unzer_invoice.tpl
@@ -138,10 +138,10 @@
 
 [{if $isCompany}]
     showB2B();
-    let unzerInstance = new unzer('[{$oViewConf->getUnzerB2BPubKey()}]');
+    let unzerInstance = new unzer('[{$oViewConf->getUnzerB2BPubKey()}]', {locale: "[{$unzerLocale}]"});
 [{else}]
     showB2C();
-    let unzerInstance = new unzer('[{$oViewConf->getUnzerB2CPubKey()}]');
+    let unzerInstance = new unzer('[{$oViewConf->getUnzerB2CPubKey()}]', {locale: "[{$unzerLocale}]"});
 [{/if}]
     let paylaterInvoice = unzerInstance.PaylaterInvoice();
     paylaterInvoice.create({

--- a/views/frontend/tpl/order/unzer_sepa.tpl
+++ b/views/frontend/tpl/order/unzer_sepa.tpl
@@ -31,7 +31,7 @@
     });
 
     // Create an Unzer instance with your public key
-    let unzerInstance = new unzer('[{$unzerpub}]');
+    let unzerInstance = new unzer('[{$unzerpub}]', {locale: "[{$unzerLocale}]"});
 
     // Create a SEPA Direct Debit instance and render the form
     let SepaDirectDebit = unzerInstance.SepaDirectDebit();

--- a/views/frontend/tpl/order/unzer_sepa_secured.tpl
+++ b/views/frontend/tpl/order/unzer_sepa_secured.tpl
@@ -73,7 +73,7 @@
 
 [{capture assign="unzerSepaDirectSecurredJS"}]
     // Create an Unzer instance with your public key
-    let unzerInstance = new unzer('[{$unzerpub}]');
+    let unzerInstance = new unzer('[{$unzerpub}]', {locale: "[{$unzerLocale}]"});
 
     // Create a SEPA Direct Debit Secured instance and render the form
     let SepaDirectDebitSecured = unzerInstance.SepaDirectDebitSecured();


### PR DESCRIPTION
UNZER v1.1.0-rc.5 (metadata.php)

- UNZER-176 authorize mode for applepay not configurable in admin area
- UNZER-191 adjusted unzer registration level and date when ordering with a guest account
- UNZER-193 refund confirmation dialog was missing the currency
- UNZER-195 apple-pay certificates weren't saved properly in admin area
  UNZER-195 bugfix reading merchant certificate and private key
- UNZER-196 refund confirmation dialog missing when refunding from total amount.
- UNZER-197 added a cancel authorization confirmation dialog
- UNZER-199 deactivate "oscunzer_sepa-secured", "oscunzer_pis" and "oscunzer_installment"
  UNZER-199 deactivate oxid payment, if the definition is inactive (only onActivate)
  UNZER-199 removed config options for "installment"
  