### PR TITLE
remove "correct" returnTypes of Methods that are extended from core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.1.2] - 2023-XX-XX
+
+### FIXED
+- compatibility-issue against other modules that also extend the moduleconfiguration
+
 ## [1.1.1] - 2023-06-19
 
 ### FIXED

--- a/metadata.php
+++ b/metadata.php
@@ -51,7 +51,7 @@ $aModule = [
             </ul>',
     ],
     'thumbnail' => 'logo.svg',
-    'version' => '1.1.1',
+    'version' => '1.1.2-rc.1',
     'author' => 'OXID eSales AG',
     'url' => 'https://www.oxid-esales.com',
     'email' => 'info@oxid-esales.com',

--- a/src/Controller/Admin/AdminOrderController.php
+++ b/src/Controller/Admin/AdminOrderController.php
@@ -60,7 +60,7 @@ class AdminOrderController extends AdminDetailsController
      *
      * @SuppressWarnings(PHPMD.ElseExpression)
      */
-    public function render(): string
+    public function render()
     {
         parent::render();
 

--- a/src/Controller/Admin/ModuleConfiguration.php
+++ b/src/Controller/Admin/ModuleConfiguration.php
@@ -47,7 +47,7 @@ class ModuleConfiguration extends ModuleConfiguration_parent
      *
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      */
-    public function render(): string
+    public function render()
     {
         parent::render();
 


### PR DESCRIPTION
In the core the returnTypes are missing. So also the returnTypes in the extension must be missing...